### PR TITLE
Fix RemoteZipPointer::populate

### DIFF
--- a/src/zip.ts
+++ b/src/zip.ts
@@ -450,7 +450,8 @@ export class RemoteZipPointer {
     }
     const contentLength = Number.parseInt(contentLengthRaw, 10);
     const endOfCentralDirectory = await this.fetchEndOfCentralDirectory(
-      contentLength
+      contentLength,
+      this.additionalHeaders
     );
     const centralDirectoryRecords = await this.fetchCentralDirectoryRecords(
       endOfCentralDirectory,


### PR DESCRIPTION
Fix passing `additionalHeaders` as second argument to `RemoteZipPointer::fetchEndOfCentralDirectory`